### PR TITLE
自動更新機能(チャット画面)

### DIFF
--- a/app/assets/javascripts/chats.js
+++ b/app/assets/javascripts/chats.js
@@ -2,7 +2,7 @@ $(function(){
   function buildChat(chat){
     var result_image = chat.image ? `<img src="${chat.image}">` : '';
     var result_content = chat.content ? chat.content : '';
-    var html = `<div class="message">
+    var html = `<div class="message" data-chat-id="${chat.id}">
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                       ${chat.user_name}
@@ -22,6 +22,8 @@ $(function(){
                 </div>`
     return html
   }
+
+  
   $('#new_chat').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -48,4 +50,30 @@ $(function(){
       $(".form__submit").removeAttr("disabled");
     })
   })
+  
+  var reloadMessages = function() {
+    var last_chat_id = $(".message").last().data("chat-id");
+    if(location.href.match('/chats')){
+      $.ajax({
+        url: 'api/chats',
+        type: 'GET',
+        data: {id: last_chat_id},
+        dataType: 'json',
+      })
+      .done(function(chats) {
+        if (chats.length != 0) {
+          chats.forEach(function(chat){
+            insertHTML = ''
+            insertHTML += buildChat(chat);
+            $(".messages").append(insertHTML);
+            $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+          })
+        }
+      })
+      .fail(function() {
+        alert('自動更新に失敗しました');
+      })
+    }
+  }
+  setInterval(reloadMessages, 5000);
 })

--- a/app/controllers/api/chats_controller.rb
+++ b/app/controllers/api/chats_controller.rb
@@ -1,0 +1,7 @@
+class Api::ChatsController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_chat_id = params[:id].to_i
+    @chats = group.chats.includes(:user).where("id > #{last_chat_id}")
+  end
+end

--- a/app/views/api/chats/index.json.jbuilder
+++ b/app/views/api/chats/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @chats do |chat|
   json.content chat.content
   json.image chat.image.url
-  json.created_at chat.created_at
+  json.created_at chat.created_at.to_s
   json.user_name chat.user.name
   json.id chat.id
 end

--- a/app/views/api/chats/index.json.jbuilder
+++ b/app/views/api/chats/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @chats do |chat|
+  json.content chat.content
+  json.image chat.image.url
+  json.created_at chat.created_at
+  json.user_name chat.user.name
+  json.id chat.id
+end

--- a/app/views/chats/_chat.html.haml
+++ b/app/views/chats/_chat.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {chat: {id:chat.id}}}
   .upper-message
     .upper-message__user-name
       = chat.user.name

--- a/app/views/chats/create.json.jbuilder
+++ b/app/views/chats/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content @chat.content
 json.image @chat.image.url
 json.created_at @chat.created_at
 json.user_name @chat.user.name
+json.id @chat.id

--- a/app/views/chats/create.json.jbuilder
+++ b/app/views/chats/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.content @chat.content
 json.image @chat.image.url
-json.created_at @chat.created_at
+json.created_at @chat.created_at.to_s
 json.user_name @chat.user.name
 json.id @chat.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :chats, only: [:index, :create]
+    namespace :api do
+      resources :chats, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What 
チャット画面を自動で更新するようにする。 chatのhtml要素にid情報を追加→ルート, コントローラを作成しindexアクションに変数を定義する→jbuilderでまとめたjson化したデータをjsに送る→jsで自動更新の記述をする。

#Why 
他のユーザーのコメントをチャット画面を自動更新することで、コメントをリアルタイムでリロードすることなく画面に反映できるようにするため。
